### PR TITLE
fix: quote csv and terminal output

### DIFF
--- a/src/core/jest-mapping.ts
+++ b/src/core/jest-mapping.ts
@@ -19,6 +19,7 @@ export interface TestResult {
   suiteSlowWarning: boolean;
   failureMessage: string;
   testFilePath: string;
+  title: string;
 }
 
 export const extractJestReports = (testData) => {

--- a/src/core/jest-mapping.ts
+++ b/src/core/jest-mapping.ts
@@ -19,7 +19,6 @@ export interface TestResult {
   suiteSlowWarning: boolean;
   failureMessage: string;
   testFilePath: string;
-  title: string;
 }
 
 export const extractJestReports = (testData) => {

--- a/src/reports/csv.ts
+++ b/src/reports/csv.ts
@@ -4,6 +4,7 @@ const { createObjectCsvWriter } = require('csv-writer');
 export const saveCsvReport = async (testResults: TestResult[], path: string) => {
   const csvWriter = createObjectCsvWriter({
     path,
+    alwaysQuote: true,
     header: [
       { id: 'testName', title: 'TESTNAME' },
       { id: 'suiteName', title: 'SUITENAME' },

--- a/src/reports/terminal/index.ts
+++ b/src/reports/terminal/index.ts
@@ -19,7 +19,7 @@ export const printTestResults = (testResults: TestResult[], logOptions: LogLevel
       (testResult) => detectLogType(testResult.duration, logOptions) === 'error'
     );
     slowTestResults.forEach((testResult) =>
-      logError(` ${formatTime(testResult.duration)} `, testResult.fullName)
+      logError(` ${formatTime(testResult.duration)} `, testResult.title)
     );
   }
 
@@ -28,7 +28,7 @@ export const printTestResults = (testResults: TestResult[], logOptions: LogLevel
       (testResult) => detectLogType(testResult.duration, logOptions) === 'warn'
     );
     mediumTestResults.forEach((testResult) =>
-      logWarn(` ${formatTime(testResult.duration)} `, testResult.fullName)
+      logWarn(` ${formatTime(testResult.duration)} `, testResult.title)
     );
   }
 
@@ -37,7 +37,7 @@ export const printTestResults = (testResults: TestResult[], logOptions: LogLevel
       (testResult) => detectLogType(testResult.duration, logOptions) === 'success'
     );
     fastTestResults.forEach((testResult) =>
-      logSuccess(` ${formatTime(testResult.duration)} `, testResult.fullName)
+      logSuccess(` ${formatTime(testResult.duration)} `, testResult.title)
     );
   }
 };

--- a/src/reports/terminal/index.ts
+++ b/src/reports/terminal/index.ts
@@ -19,7 +19,7 @@ export const printTestResults = (testResults: TestResult[], logOptions: LogLevel
       (testResult) => detectLogType(testResult.duration, logOptions) === 'error'
     );
     slowTestResults.forEach((testResult) =>
-      logError(` ${formatTime(testResult.duration)} `, testResult.title)
+      logError(` ${formatTime(testResult.duration)} `, testResult.testName)
     );
   }
 
@@ -28,7 +28,7 @@ export const printTestResults = (testResults: TestResult[], logOptions: LogLevel
       (testResult) => detectLogType(testResult.duration, logOptions) === 'warn'
     );
     mediumTestResults.forEach((testResult) =>
-      logWarn(` ${formatTime(testResult.duration)} `, testResult.title)
+      logWarn(` ${formatTime(testResult.duration)} `, testResult.testName)
     );
   }
 
@@ -37,7 +37,7 @@ export const printTestResults = (testResults: TestResult[], logOptions: LogLevel
       (testResult) => detectLogType(testResult.duration, logOptions) === 'success'
     );
     fastTestResults.forEach((testResult) =>
-      logSuccess(` ${formatTime(testResult.duration)} `, testResult.title)
+      logSuccess(` ${formatTime(testResult.duration)} `, testResult.testName)
     );
   }
 };


### PR DESCRIPTION
This PR sets the csv writer to always quote its fields to prevent ingest errors when they contain commas, and also changes the field the reporter uses for terminal output to a valid one to prevent receiving undefined outputs.